### PR TITLE
Connect to externel docker host through docker-machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "docker-version": "1.5.0",
-  "docker-machine-version": "0.1.0-kitematic-0.5.10",
+  "docker-machine-version": "0.1.0-hypriot-1",
   "atom-shell-version": "0.21.3",
   "virtualbox-version": "4.3.24",
   "virtualbox-filename": "VirtualBox-4.3.24.pkg",

--- a/src/DockerMachine.js
+++ b/src/DockerMachine.js
@@ -84,7 +84,11 @@ var DockerMachine = {
     });
   },
   regenerateCerts: function () {
-    return util.exec([DockerMachine.command(), 'tls-regenerate-certs', '-f', NAME]);
+//+++
+//disable call to connect an external Docker Host
+//    return util.exec([DockerMachine.command(), 'tls-regenerate-certs', '-f', NAME]);
+    return Promise.resolve();
+//---
   },
   state: function () {
     return DockerMachine.info().then(info => {

--- a/util/deps
+++ b/util/deps
@@ -13,7 +13,8 @@ if [ ! -f $DOCKER_MACHINE_CLI_FILE ]; then
   rm -rf docker-machine*
   # Use temporary, new version of docker-machine that has some important fixes
   # curl -L -o $DOCKER_MACHINE_CLI_FILE https://github.com/docker/machine/releases/download/v$DOCKER_MACHINE_CLI_VERSION/docker-machine_darwin-amd64
-  curl -L -o $DOCKER_MACHINE_CLI_FILE https://github.com/kitematic/kitematic/releases/download/v0.5.10/docker-machine_darwin-amd64
+  #curl -L -o $DOCKER_MACHINE_CLI_FILE https://github.com/kitematic/kitematic/releases/download/v0.5.10/docker-machine_darwin-amd64
+  curl -kL -o $DOCKER_MACHINE_CLI_FILE https://assets.hypriot.com/docker-machine_darwin-amd64-$DOCKER_MACHINE_CLI_VERSION
   chmod +x $DOCKER_MACHINE_CLI_FILE
 fi
 


### PR DESCRIPTION
We are using a special version of 'docker-machine' which has a driver 'hypriot' built-in (details can be found in this PR https://github.com/hypriot/machine/pull/1).

To create a machine for an already existing Boot2Docker VM, just use the following command:

```
docker-machine create --driver=hypriot --hypriot-docker-ipaddress=192.168.59.103 dev
```

Then you have to copy your certs, key files to this directory:

```
cp ~/.boot2docker/certs/boot2docker-vm/* ~/.docker/machine/machines/dev/
cp ~/.ssh/id_boot2docker ~/.docker/machine/machines/dev/id_rsa
cp ~/.ssh/id_boot2docker.pub ~/.docker/machine/machines/dev/id_rsa.pub
```

```
🐳  ls -al ~/.docker/machine/machines/dev/
-rw-r--r--  1 dieter  staff  1042 Mar 14 18:36 ca.pem
-rw-r--r--  1 dieter  staff  1066 Mar 14 18:36 cert.pem
-rw-------  1 dieter  staff   320 Mar 14 18:32 config.json
-rw-------  1 dieter  staff  1675 Mar 14 21:55 id_rsa
-rw-r--r--  1 dieter  staff   414 Mar 14 21:55 id_rsa.pub
-rw-r--r--  1 dieter  staff  1675 Mar 14 18:36 key.pem
```

That's all for this POC.
